### PR TITLE
Set Click fixed to 6.7 as required by Goodtables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'sphinx-commands': ['sphinx']
     },
     install_requires=[
-        'Click',
+        'Click==6.7',
         'fiona',
         'shapely',
         'geojson_utils',


### PR DESCRIPTION
Tried the installation from scratch and came across this issue. Fixed by setting specific version.